### PR TITLE
puppet expects a String, not a Float

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,8 +69,8 @@ class pgtune (
 
   # Checkpoint completion target
   case $db_type {
-    'web':     { $checkpoint_completion_target = 0.7 }
-    default:   { $checkpoint_completion_target = 0.9 }
+    'web':     { $checkpoint_completion_target = '0.7' }
+    default:   { $checkpoint_completion_target = '0.9' }
   }
 
   # Default statistics target


### PR DESCRIPTION
Hi!

On puppetlabs/postgresql version i experienced an issue with pgtune handing over a Float. This patch fixed it for me.

```
Notice: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[wal_buffers]/Postgresql_conf[wal_buffers]/ensure: created
Info: Computing checksum on file /etc/postgresql/9.3/main/postgresql.conf
Info: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[wal_buffers]/Postgresql_conf[wal_buffers]: Scheduling refresh of Class[Postgresql::Server::Service]
Notice: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[checkpoint_segments]/Postgresql_conf[checkpoint_segments]/ensure: created
Info: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[checkpoint_segments]/Postgresql_conf[checkpoint_segments]: Scheduling refresh of Class[Postgresql::Server::Reload]
Notice: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[checkpoint_completion_target]/Postgresql_conf[checkpoint_completion_target]/ensure: created
Error: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[checkpoint_completion_target]/Postgresql_conf[checkpoint_completion_target]: Could not evaluate: undefined method `match' for
 0.7:Float
Notice: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[maintenance_work_mem]/Postgresql_conf[maintenance_work_mem]/ensure: created
Error: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[maintenance_work_mem]/Postgresql_conf[maintenance_work_mem]: Could not evaluate: undefined method `match' for 0.7:Float
Notice: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[shared_buffers]/Postgresql_conf[shared_buffers]/value: value changed '128MB' to '498MB'
Error: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[shared_buffers]/Postgresql_conf[shared_buffers]: Could not evaluate: undefined method `match' for 0.7:Float
Notice: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[effective_cache_size]/Postgresql_conf[effective_cache_size]/ensure: created
Error: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[effective_cache_size]/Postgresql_conf[effective_cache_size]: Could not evaluate: undefined method `match' for 0.7:Float
Notice: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[max_connections]/Postgresql_conf[max_connections]/value: value changed '100' to '200'
Error: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[max_connections]/Postgresql_conf[max_connections]: Could not evaluate: undefined method `match' for 0.7:Float
Notice: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[default_statistics_target]/Postgresql_conf[default_statistics_target]/ensure: created
Error: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[default_statistics_target]/Postgresql_conf[default_statistics_target]: Could not evaluate: undefined method `match' for 0.7:F
loat
Notice: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[work_mem]/Postgresql_conf[work_mem]/ensure: created
Error: /Stage[main]/Pgtune/Postgresql::Server::Config_entry[work_mem]/Postgresql_conf[work_mem]: Could not evaluate: undefined method `match' for 0.7:Float
```
