### PR TITLE
fix comparing versions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,7 +121,8 @@ class pgtune (
     value => inline_template('<%= [2048, @maintenance_work_mem.to_i ].min.floor %>MB'),
   }
 
-  if $postgresql::repo::version > '9.4' {
+  # return 1 if version A is greater than version B
+  if versioncmp($postgresql::repo::version, '9.4') > 0 {
 
     postgresql::server::config_entry { 'min_wal_size':
       value => $min_wal_size,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,7 +123,7 @@ class pgtune (
 
   # return 1 if version A is greater than version B
   $postgres_version = $postgresql::globals::globals_version
-  if $postgres_version != 'unknown' and versioncmp($postgres_version, '9.4') > 0 {
+  if versioncmp($postgres_version, '9.4') > 0 {
 
     postgresql::server::config_entry { 'min_wal_size':
       value => $min_wal_size,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,8 @@ class pgtune (
   }
 
   # return 1 if version A is greater than version B
-  if versioncmp($postgresql::repo::version, '9.4') > 0 {
+  $postgres_version = $postgresql::globals::globals_version
+  if $postgres_version != 'unknown' and versioncmp($postgres_version, '9.4') > 0 {
 
     postgresql::server::config_entry { 'min_wal_size':
       value => $min_wal_size,


### PR DESCRIPTION
Semantic versions can't be compared using `>` operator. Puppet 4 throws following error:

```
 Comparison of: Undef Value > String, is not possible. Caused by 'Only Strings, Numbers, and Versions are comparable'
```

It's better to use builtin function `versioncmp` (see [docs](https://docs.puppet.com/puppet/latest/reference/function.html#versioncmp)).
